### PR TITLE
Remove the releaseDate minimum restriction

### DIFF
--- a/lib/schemas/add_book_request.json
+++ b/lib/schemas/add_book_request.json
@@ -17,8 +17,7 @@
     },
     "releaseDate": {
       "type": "integer",
-      "title": "Release Date",
-      "minimum": 0
+      "title": "Release Date"
     },
     "authorName": {
       "type": "string",


### PR DESCRIPTION
Unix timestamps encode dates as seconds since 01 jan 1970.

For this reason the only way to encode dates before this time using
unix timestamps is to use negative integers.