### PR TITLE
Replace arrow functions with regular functions in mocha tests

### DIFF
--- a/test/unit/adapters/db/create.test.js
+++ b/test/unit/adapters/db/create.test.js
@@ -20,8 +20,8 @@ const stubs = {
 };
 const createDbAdapterMock = proxyquire('../../../../lib/adapters/db/create', stubs);
 
-describe('create', () => {
-  it('should create a book', async () => {
+describe('create', function() {
+  it('should create a book', async function() {
     // setup
     const tableNameMock = chance.word();
     const paramsMock = {
@@ -60,7 +60,7 @@ describe('create', () => {
       });
   });
 
-  it('should return an error', async () => {
+  it('should return an error', async function() {
     // setup
     const tableNameMock = chance.word();
     const paramsMock = {
@@ -98,7 +98,7 @@ describe('create', () => {
       });
   });
 
-  it('should return a tableName bad argument error', async () => {
+  it('should return a tableName bad argument error', async function() {
     // setup
     const tableNameMock = undefined;
     const paramsMock = {};
@@ -114,7 +114,7 @@ describe('create', () => {
       });
   });
 
-  it('should return a params bad argument error', async () => {
+  it('should return a params bad argument error', async function() {
     // setup
     const tableNameMock = chance.word();
     const paramsMock = undefined;

--- a/test/unit/adapters/db/delete.test.js
+++ b/test/unit/adapters/db/delete.test.js
@@ -18,8 +18,8 @@ const stubs = {
 };
 const deleteDbAdapterMock = proxyquire('../../../../lib/adapters/db/delete', stubs);
 
-describe('delete', () => {
-  it('should delete a book', async () => {
+describe('delete', function() {
+  it('should delete a book', async function() {
     // setup
     const tableNameMock = chance.word();
     const uuidMock = uuidv4();
@@ -56,7 +56,7 @@ describe('delete', () => {
       });
   });
 
-  it('should return an error', async () => {
+  it('should return an error', async function() {
     // setup
     const tableNameMock = chance.word();
     const uuidMock = uuidv4();
@@ -89,7 +89,7 @@ describe('delete', () => {
       });
   });
 
-  it('should return a tableName bad argument error', async () => {
+  it('should return a tableName bad argument error', async function() {
     // setup
     const tableNameMock = undefined;
     const uuidMock = '';
@@ -105,7 +105,7 @@ describe('delete', () => {
       });
   });
 
-  it('should return a uuid bad argument error', async () => {
+  it('should return a uuid bad argument error', async function() {
     // setup
     const tableNameMock = chance.word();
     const uuidMock = undefined;

--- a/test/unit/adapters/db/get.test.js
+++ b/test/unit/adapters/db/get.test.js
@@ -22,8 +22,8 @@ const stubs = {
 };
 const getDbAdapterMock = proxyquire('../../../../lib/adapters/db/get', stubs);
 
-describe('get', () => {
-  it('should get a book', async () => {
+describe('get', function() {
+  it('should get a book', async function() {
     // setup
     const tableNameMock = chance.word();
     const uuidMock = uuidv4();
@@ -61,7 +61,7 @@ describe('get', () => {
       });
   });
 
-  it('should return an error', async () => {
+  it('should return an error', async function() {
     // setup
     const tableNameMock = chance.word();
     const uuidMock = uuidv4();
@@ -93,7 +93,7 @@ describe('get', () => {
       });
   });
 
-  it('should return a tableName bad argument error', async () => {
+  it('should return a tableName bad argument error', async function() {
     // setup
     const tableNameMock = undefined;
     const uuidMock = '';
@@ -109,7 +109,7 @@ describe('get', () => {
       });
   });
 
-  it('should return a uuid bad argument error', async () => {
+  it('should return a uuid bad argument error', async function() {
     // setup
     const tableNameMock = chance.word();
     const uuidMock = undefined;

--- a/test/unit/adapters/db/getAll.test.js
+++ b/test/unit/adapters/db/getAll.test.js
@@ -18,8 +18,8 @@ const stubs = {
 };
 const getAllDbAdapterMock = proxyquire('../../../../lib/adapters/db/getAll', stubs);
 
-describe('getAll', () => {
-  it('should get all books', async () => {
+describe('getAll', function() {
+  it('should get all books', async function() {
     // setup
     const tableNameMock = chance.word();
     const bookMock1 = {
@@ -62,7 +62,7 @@ describe('getAll', () => {
       });
   });
 
-  it('should return an error', async () => {
+  it('should return an error', async function() {
     // setup
     const tableNameMock = chance.word();
     const getAllResultMock = Promise.reject(new Error('oh noes!'));
@@ -92,7 +92,7 @@ describe('getAll', () => {
       });
   });
 
-  it('should return a tableName bad argument error', async () => {
+  it('should return a tableName bad argument error', async function() {
     // setup
     const tableNameMock = undefined;
 

--- a/test/unit/adapters/db/update.test.js
+++ b/test/unit/adapters/db/update.test.js
@@ -14,8 +14,8 @@ const stubs = {
 };
 const updateDbAdapterMock = proxyquire('../../../../lib/adapters/db/update', stubs);
 
-describe('update', () => {
-  it('should update a book', async () => {
+describe('update', function() {
+  it('should update a book', async function() {
     // setup
     const tableNameMock = chance.word();
     const paramsMock = {
@@ -52,7 +52,7 @@ describe('update', () => {
       });
   });
 
-  it('should return an error', async () => {
+  it('should return an error', async function() {
     // setup
     const tableNameMock = chance.word();
     const paramsMock = {
@@ -90,7 +90,7 @@ describe('update', () => {
       });
   });
 
-  it('should return a tableName bad argument error', async () => {
+  it('should return a tableName bad argument error', async function() {
     // setup
     const tableNameMock = undefined;
     const uuidMock = uuidv4();
@@ -107,7 +107,7 @@ describe('update', () => {
       });
   });
 
-  it('should return a uuid bad argument error', async () => {
+  it('should return a uuid bad argument error', async function() {
     // setup
     const tableNameMock = chance.word();
     const uuidMock = undefined;
@@ -124,7 +124,7 @@ describe('update', () => {
       });
   });
 
-  it('should return a params bad argument error', async () => {
+  it('should return a params bad argument error', async function() {
     // setup
     const tableNameMock = chance.word();
     const uuidMock = uuidv4();

--- a/test/unit/adapters/index.js
+++ b/test/unit/adapters/index.js
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 /* eslint-disable no-unused-expressions */
 
-describe('adapters', () => {
+describe('adapters', function() {
   require('./db');
 });

--- a/test/unit/functions/add.test.js
+++ b/test/unit/functions/add.test.js
@@ -15,7 +15,7 @@ const stubs = {
 const handlerMock = proxyquire('../../../lib/functions/add', stubs);
 
 describe('add', () => {
-  it('should create a book', async () => {
+  it('should create a book', async function() {
     // setup
     const paramsMock = {
       name: chance.sentence(),
@@ -40,7 +40,7 @@ describe('add', () => {
     expect(booksUtilStub.addBook.calledOnce).to.be.true;
   });
 
-  it('should return a 500 error', async () => {
+  it('should return a 500 error', async function() {
     // setup
     const eventMock = {
       body: JSON.stringify({})

--- a/test/unit/functions/delete.test.js
+++ b/test/unit/functions/delete.test.js
@@ -14,8 +14,8 @@ const stubs = {
 };
 const handlerMock = proxyquire('../../../lib/functions/delete', stubs);
 
-describe('delete', () => {
-  it('should delete a book', async () => {
+describe('delete', function() {
+  it('should delete a book', async function() {
     // setup
     const uuidMock = uuidv4();
     const eventMock = {
@@ -42,7 +42,7 @@ describe('delete', () => {
     expect(booksStub.deleteBook.calledOnce).to.be.true;
   });
 
-  it('should return a 404 error', async () => {
+  it('should return a 404 error', async function() {
     // setup
     const uuidMock = uuidv4();
     const eventMock = {
@@ -66,7 +66,7 @@ describe('delete', () => {
     expect(booksStub.deleteBook.calledOnce).to.be.true;
   });
 
-  it('should throw a 500 error', async () => {
+  it('should throw a 500 error', async function() {
     // setup
     const uuidMock = uuidv4();
     const eventMock = {

--- a/test/unit/functions/get.test.js
+++ b/test/unit/functions/get.test.js
@@ -14,8 +14,8 @@ const stubs = {
 };
 const handlerMock = proxyquire('../../../lib/functions/get', stubs);
 
-describe('get', () => {
-  it('should get a book', async () => {
+describe('get', function() {
+  it('should get a book', async function() {
     // setup
     const uuidMock = uuidv4();
     const eventMock = {
@@ -42,7 +42,7 @@ describe('get', () => {
     expect(booksStub.getBook.calledOnce).to.be.true;
   });
 
-  it('should return a 404 error', async () => {
+  it('should return a 404 error', async function() {
     // setup
     const uuidMock = uuidv4();
     const eventMock = {
@@ -65,7 +65,7 @@ describe('get', () => {
     }));
   });
 
-  it('should return a 500 error', async () => {
+  it('should return a 500 error', async function() {
     // setup
     const uuidMock = uuidv4();
     const eventMock = {

--- a/test/unit/functions/getAll.test.js
+++ b/test/unit/functions/getAll.test.js
@@ -14,8 +14,8 @@ const stubs = {
 };
 const handlerMock = proxyquire('../../../lib/functions/getAll', stubs);
 
-describe('getAll', () => {
-  it('should get all books', async () => {
+describe('getAll', function() {
+  it('should get all books', async function() {
     // setup
     const eventMock = {};
     const getAllBooksMock = [
@@ -45,7 +45,7 @@ describe('getAll', () => {
     expect(booksStub.getAllBooks.calledOnce).to.be.true;
   });
 
-  it('should return a 500 error', async () => {
+  it('should return a 500 error', async function() {
     // setup
     const eventMock = {};
     const getAllResult = Promise.reject(new Error('oh noes!'));

--- a/test/unit/functions/hello.test.js
+++ b/test/unit/functions/hello.test.js
@@ -6,8 +6,8 @@ const expect = require('chai').expect;
 
 const handler = require('../../../lib/functions/hello');
 
-describe('hello', () => {
-  it('should return a response', async () => {
+describe('hello', function() {
+  it('should return a response', async function() {
     const response = await handler.hello({});
     expect(response).to.not.be.empty;
     expect(response.statusCode).to.be.equal(200);

--- a/test/unit/functions/index.js
+++ b/test/unit/functions/index.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* eslint-disable no-unused-expressions */
 
-describe('functions', () => {
+describe('functions', function() {
   require('./hello.test.js');
   require('./add.test.js');
   require('./delete.test.js');

--- a/test/unit/functions/update.test.js
+++ b/test/unit/functions/update.test.js
@@ -14,8 +14,8 @@ const stubs = {
 };
 const handlerMock = proxyquire('../../../lib/functions/update', stubs);
 
-describe('update', () => {
-  it('should update a book', async () => {
+describe('update', function() {
+  it('should update a book', async function() {
     // setup
     const uuidMock = uuidv4();
     const eventMock = {
@@ -43,7 +43,7 @@ describe('update', () => {
     expect(booksStub.updateBook.calledOnce).to.be.true;
   });
 
-  it('should return a 404 error', async () => {
+  it('should return a 404 error', async function() {
     // setup
     const uuidMock = uuidv4();
     const eventMock = {
@@ -68,7 +68,7 @@ describe('update', () => {
     expect(booksStub.updateBook.calledOnce).to.be.true;
   });
 
-  it('should throw a 500 error', async () => {
+  it('should throw a 500 error', async function() {
     // setup
     const uuidMock = uuidv4();
     const eventMock = {

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-expressions */
 'use strict';
 
-describe('unit tests', () => {
+describe('unit tests', function() {
   require('./adapters');
   require('./functions');
   require('./utils');

--- a/test/unit/utils/addBook.test.js
+++ b/test/unit/utils/addBook.test.js
@@ -20,8 +20,8 @@ const stubs = {
 };
 const addBookUtilMock = proxyquire('../../../lib/utils/addBook', stubs);
 
-describe('addBook', () => {
-  it('should add a book', async () => {
+describe('addBook', function() {
+  it('should add a book', async function() {
     // setup
     const uuidMock = uuidv4();
     const paramsMock = {
@@ -44,7 +44,7 @@ describe('addBook', () => {
       });
   });
 
-  it('should return an error', async () => {
+  it('should return an error', async function() {
     // setup
     const uuidMock = uuidv4();
     const paramsMock = {
@@ -70,7 +70,7 @@ describe('addBook', () => {
       });
   });
 
-  it('should return a params bad argument error', async () => {
+  it('should return a params bad argument error', async function() {
     // setup
     const paramsMock = undefined;
 

--- a/test/unit/utils/deleteBook.test.js
+++ b/test/unit/utils/deleteBook.test.js
@@ -18,8 +18,8 @@ const stubs = {
 };
 const deleteBookUtilMock = proxyquire('../../../lib/utils/deleteBook', stubs);
 
-describe('deleteBook', () => {
-  it('should delete a book', async () => {
+describe('deleteBook', function() {
+  it('should delete a book', async function() {
     // setup
     const uuidMock = uuidv4();
     const deletedBookMock = {
@@ -42,7 +42,7 @@ describe('deleteBook', () => {
       });
   });
 
-  it('should return an error', async () => {
+  it('should return an error', async function() {
     // setup
     const uuidMock = uuidv4();
     const deleteResultMock = Promise.reject(new Error('oh noes!'));
@@ -63,7 +63,7 @@ describe('deleteBook', () => {
       });
   });
 
-  it('should return a uuid bad argument error', async () => {
+  it('should return a uuid bad argument error', async function() {
     // setup
     const uuidMock = undefined;
 

--- a/test/unit/utils/getAllBooks.test.js
+++ b/test/unit/utils/getAllBooks.test.js
@@ -18,8 +18,8 @@ const stubs = {
 };
 const getAllBooksUtilMock = proxyquire('../../../lib/utils/getAllBooks', stubs);
 
-describe('getAllBooks', () => {
-  it('should get all books', async () => {
+describe('getAllBooks', function() {
+  it('should get all books', async function() {
     // setup
     const bookListMock = [
       {
@@ -49,7 +49,7 @@ describe('getAllBooks', () => {
       });
   });
 
-  it('should return an error', async () => {
+  it('should return an error', async function() {
     // setup
     const getAllResultMock = Promise.reject(new Error('oh noes!'));
     dbAdapterStub.getAll = sinon.stub().returns(getAllResultMock);

--- a/test/unit/utils/getBook.test.js
+++ b/test/unit/utils/getBook.test.js
@@ -18,8 +18,8 @@ const stubs = {
 };
 const getBookUtilMock = proxyquire('../../../lib/utils/getBook', stubs);
 
-describe('getBook', () => {
-  it('should get a book', async () => {
+describe('getBook', function() {
+  it('should get a book', async function() {
     // setup
     const getBookMock = {
       uuid: uuidv4(),
@@ -41,7 +41,7 @@ describe('getBook', () => {
       });
   });
 
-  it('should return a 500 error', async () => {
+  it('should return a 500 error', async function() {
     // setup
     const uuidMock = uuidv4();
     const getResultMock = Promise.reject(new Error('oh noes!'));
@@ -62,7 +62,7 @@ describe('getBook', () => {
       });
   });
 
-  it('should return a uuid bad argument error', async () => {
+  it('should return a uuid bad argument error', async function() {
     // setup
     const uuidMock = undefined;
 

--- a/test/unit/utils/index.js
+++ b/test/unit/utils/index.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-expressions */
 'use strict';
 
-describe('utils', () => {
+describe('utils', function() {
   require('./addBook.test.js');
   require('./deleteBook.test.js');
   require('./getBook.test.js');

--- a/test/unit/utils/updateBook.test.js
+++ b/test/unit/utils/updateBook.test.js
@@ -19,7 +19,7 @@ const stubs = {
 const updateBookUtilMock = proxyquire('../../../lib/utils/updateBook', stubs);
 
 describe('updateBook', () => {
-  it('should return a book object', async () => {
+  it('should return a book object', async function() {
     // setup
     const uuidMock = uuidv4();
     const paramsMock = {


### PR DESCRIPTION
It turns out that because of how mocha is implemented, tests can
malfunction if arrow functions are used in test descriptions because
they change the context available in the tests.